### PR TITLE
Logan/set reactive query

### DIFF
--- a/src/PublicationModel.js
+++ b/src/PublicationModel.js
@@ -155,7 +155,7 @@ var PublicationModel = Backbone.Model.extend({
    *    `PublicationClient::LocalCollection::find`.
    */
   setReactiveQuery(query) {
-    if (this._reactiveQuery) this._reactiveQuery.stopObservingChanges();
+    if (this._reactiveQuery) this.stopObservingChanges();
     this._reactiveQuery = query;
   },
 

--- a/src/PublicationModel.js
+++ b/src/PublicationModel.js
@@ -160,7 +160,7 @@ var PublicationModel = Backbone.Model.extend({
   },
 
   /**
-   * Stop listening to the events establishedd in `startObservingChanges`.
+   * Stop listening to the events established in `startObservingChanges`.
    */
   stopObservingChanges() {
     this._reactiveQuery


### PR DESCRIPTION
Previously, setReactiveQuery() was looking for a stopObservingChanges
method on the model's _reactiveQuery. That's actually a method on the
model itself, not on the query, so this was broken. This commit fixes
the issue.