### PR TITLE
Fix non plain objects being considered as such.

### DIFF
--- a/spec/PublicationModelSpec.js
+++ b/spec/PublicationModelSpec.js
@@ -90,5 +90,27 @@ describe('PublicationModel', () => {
       model.set({ foo: 'bar', bar: { qux: date } });
       model.set({ foo: 'hello', bar: { qux: date, baz: true } });
     });
+
+    it('should not change value of a nested date object when setting another property', function () {
+      const date = new Date("2017-09-07T23:23:00.000Z");
+
+      const data = {
+        foo: 'bar',
+        wubble: 'hi',
+        baz: {
+          qux: new Date('2017-09-07T23:23:00.000Z')
+        }
+      };
+
+      const model = new PublicationModel(data);
+
+      expect(model.get('baz').qux).toEqual(jasmine.any(Date));
+      expect(model.get('baz').qux).toEqual(date);
+
+      model.set('wubble', 'foo');
+
+      expect(model.get('baz').qux).toEqual(jasmine.any(Date));
+      expect(model.get('baz').qux).toEqual(date);
+    });
   });
 });

--- a/src/PublicationModel.js
+++ b/src/PublicationModel.js
@@ -83,7 +83,7 @@ var PublicationModel = Backbone.Model.extend({
      * the new attributes are in place. We also determine if all the changes were to nested
      * objects - if so, we don't emit any events (but still call `set` so the new attributes are
      * stored on the model).  */
-    var allChangesAreObjects = _.every(changedAttributes, v => _.isObject(v));
+    var allChangesAreObjects = _.every(changedAttributes, ObjectUtils.isPlainObject);
     var standardOpts = _.extend({}, options, { silent: allChangesAreObjects });
     if (options.unset) {
       PublicationModel.__super__.unset.call(this, changedAttributes, standardOpts);
@@ -94,7 +94,7 @@ var PublicationModel = Backbone.Model.extend({
     if (!options.silent) {
       // Trigger events for any nested objects.
       _.each(changedAttributes, (value, key, attributes) => {
-        if (_.isObject(value)) this.trigger('change:' + key, this, attributes[key], options);
+        if (ObjectUtils.isPlainObject(value)) this.trigger('change:' + key, this, attributes[key], options);
       });
 
       // NOTE: Do not rely on this event passing the changed attributes. This does not conform to

--- a/src/utils/ObjectUtils.js
+++ b/src/utils/ObjectUtils.js
@@ -83,7 +83,7 @@ var ObjectUtils = {
   deepClone: function(source) {
     var clone = _.clone(source);
     _.each(clone, (v,k) => {
-      if (_.isObject(v)) {
+      if (isPlainObject(v)) {
         clone[k] = ObjectUtils.deepClone(v);
       }
     });


### PR DESCRIPTION
This is very similar to: https://github.com/mixmaxhq/backbone-publication/pull/16

The issue was that there was another case that was not covered in the above PR. I've replaced all code using `_.isObject` for checking for plain old objects.