### PR TITLE
chore: upgrade natives to 1.1.6 for node 10 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5352,9 +5352,9 @@
       }
     },
     "natives": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.3.tgz",
-      "integrity": "sha512-BZGSYV4YOLxzoTK73l0/s/0sH9l8SHs2ocReMH1f8JYSh5FUWu4ZrKCpJdRkWXV6HFR/pZDz7bwWOVAY07q77g==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.6.tgz",
+      "integrity": "sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==",
       "dev": true
     },
     "natural-compare": {


### PR DESCRIPTION
## Test plan:

- [x] `npm install` -- check it works