### PR TITLE
fix(collection): prevent exception on initialization

### DIFF
--- a/spec/PublicationCollectionSpec.js
+++ b/spec/PublicationCollectionSpec.js
@@ -1,0 +1,10 @@
+import PublicationCollection from '../src/PublicationCollection';
+
+describe('PublicationCollection', () => {
+  describe('#initialize', () => {
+    it('should successfully initialize with no parameters', () => {
+      const collection = new PublicationCollection();
+      expect(collection.length).toBe(0);
+    });
+  });
+});

--- a/spec/PublicationCollectionSpec.js
+++ b/spec/PublicationCollectionSpec.js
@@ -6,5 +6,14 @@ describe('PublicationCollection', () => {
       const collection = new PublicationCollection();
       expect(collection.length).toBe(0);
     });
+
+    it('should successfully initialize when waitOn is true', () => {
+      const collection = new PublicationCollection(undefined, {
+        waitOn: {
+          whenReady: () => Promise.resolve()
+        }
+      });
+      expect(collection.length).toBe(0);
+    });
   });
 });

--- a/src/PublicationCollection.js
+++ b/src/PublicationCollection.js
@@ -50,7 +50,7 @@ var PublicationCollection = Backbone.Collection.extend({
         // Once the relevant subscription is ready, reset the collection to the
         // current state of the result set. (We've skipped over the initial
         // 'add' events.)
-        this.reset(this._reactiveQuery.fetch());
+        if (this._reactiveQuery) this.reset(this._reactiveQuery.fetch());
         this.startObservingChanges();
       });
     } else if (options.startObservingChanges) {

--- a/src/PublicationCollection.js
+++ b/src/PublicationCollection.js
@@ -101,6 +101,7 @@ var PublicationCollection = Backbone.Collection.extend({
    * Starts observing the reactive query for changes.
    */
   startObservingChanges() {
+    if (!this._reactiveQuery) return;
     this._reactiveQuery
       .on('added', this._boundOnAdded)
       .on('changed', this._boundOnChanged)
@@ -111,6 +112,7 @@ var PublicationCollection = Backbone.Collection.extend({
    * Stop listening to the events established in `startObservingChanges`.
    */
   stopObservingChanges() {
+    if (!this._reactiveQuery) return;
     this._reactiveQuery
       .removeListener('added', this._boundOnAdded)
       .removeListener('changed', this._boundOnChanged)


### PR DESCRIPTION
This allows us to instantiate PublicationCollections with no options and
no models. Previously this would fail even though it just means we can't
start publications.